### PR TITLE
Fixes

### DIFF
--- a/linux_mint.yaml
+++ b/linux_mint.yaml
@@ -322,9 +322,9 @@
     - base
     - downloads
     - apps
-  - name: put_desktop_files_for_application
+  - name: put_desktop_files_for_applications
     copy:
-      dest: /usr/share/application
+      dest: /usr/share/applications
       src: "{{ item.desktop_file }}"
       owner: root
       group: root

--- a/mint19.yaml
+++ b/mint19.yaml
@@ -238,7 +238,6 @@ packages:
 - testdisk
 - partclone
 - clonezilla
-- rdesktop
 - httpie
 - ngrep
 - tshark

--- a/mint19.yaml
+++ b/mint19.yaml
@@ -232,7 +232,7 @@ packages:
 - asbru-cm
 - iperf3
 - traceroute
-- nfs-client
+- nfs-common
 - rdesktop
 - gddrescue
 - testdisk


### PR DESCRIPTION
The copying of *.desktop files ended up creating and overwriting "/usr/share/application" file rather than copying to the "/usr/share/applications" directory

As for duplicate entry... perhaps some linting/check of the yaml lists?