### PR TITLE
Change ansible to ansible-base for 2.10.x support

### DIFF
--- a/mint20.yaml
+++ b/mint20.yaml
@@ -154,7 +154,7 @@ packages_essential:
 - xz-utils
 packages:
 - synaptic
-- ansible
+- ansible-base
 - azure-cli
 - google-cloud-sdk
 - gcsfuse


### PR DESCRIPTION
Change package ansible to ansible-base to support this playbook requirements of 2.10.x and avoid failure on subsequent runs.